### PR TITLE
Slack OAuthの対応

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+sslServer.js

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ yarn-error.log*
 # local env files
 .env
 .env*.local
+certificates/*.crt
+certificates/*.key
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "next start",
     "dev": "next dev",
+    "dev:ssl": "node sslServer.js",
     "build": "next build",
     "lint": "next lint",
     "prettier:check": "prettier --check ./src/**/*.{ts,tsx}",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,13 +16,12 @@ model Example {
   updatedAt DateTime @updatedAt
 }
 
-// Necessary for Next auth
 model Account {
   id                String  @id @default(cuid())
-  userId            String
+  userId            String  @map("user_id")
   type              String
   provider          String
-  providerAccountId String
+  providerAccountId String  @map("provider_account_id")
   refresh_token     String? @db.Text
   access_token      String? @db.Text
   expires_at        Int?
@@ -30,27 +29,33 @@ model Account {
   scope             String?
   id_token          String? @db.Text
   session_state     String?
+
   user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+  @@map("accounts")
 }
 
 model Session {
   id           String   @id @default(cuid())
-  sessionToken String   @unique
-  userId       String
+  sessionToken String   @unique @map("session_token")
+  userId       String   @map("user_id")
   expires      DateTime
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("sessions")
 }
 
 model User {
   id            String    @id @default(cuid())
   name          String?
   email         String?   @unique
-  emailVerified DateTime?
+  emailVerified DateTime? @map("email_verified")
   image         String?
   accounts      Account[]
   sessions      Session[]
+
+  @@map("users")
 }
 
 model VerificationToken {
@@ -59,4 +64,5 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
+  @@map("verificationtokens")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,8 @@ model Account {
   scope             String?
   id_token          String? @db.Text
   session_state     String?
+  ok                Boolean?
+  state             String?
 
   user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/sslServer.js
+++ b/sslServer.js
@@ -1,0 +1,23 @@
+const { createServer } = require('https')
+const { parse } = require('url')
+const next = require('next')
+const fs = require('fs')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+const handle = app.getRequestHandler()
+
+const httpsOptions = {
+  key: fs.readFileSync('./certificates/localhost.key'),
+  cert: fs.readFileSync('./certificates/localhost.crt')
+}
+
+app.prepare().then(() => {
+  createServer(httpsOptions, (req, res) => {
+    const parsedUrl = parse(req.url, true)
+    handle(req, res, parsedUrl)
+  }).listen(3000, (err) => {
+    if (err) throw err
+    console.log("> Next.js SSL supported dev Server is READY.")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "noUncheckedIndexedAccess": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "sslServer.js"]
 }


### PR DESCRIPTION
## What does this PR do ? / PRの目的
NextAuthでSlack OAuthをするための設定を追加

## Implementations / 実装したこと
- NextAuthとPrismaを組み合わせる際のテンプレートの命名規則がよくないため統一する設定を実装
- PrismaにSlack OAuthに必要なカラムを実装
- Slack OAuthの`Callback URL`にはhttpsなURLのみしか指定できないため、そのためのSSL対応のカスタムサーバを追加

## References / 参考資料
- [Prisma Adapter](https://next-auth.js.org/adapters/prisma)
- [Custom Server](https://next-auth.js.org/providers/apple#deploy-to-server)