### PR TITLE
CIにPrisma Schemaのバリデーションを追加

### DIFF
--- a/.github/workflows/prisma-schema.yml
+++ b/.github/workflows/prisma-schema.yml
@@ -1,0 +1,27 @@
+name: Prisma Schema Validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ develop ]
+
+env:
+  DATABASE_URL: ${{ secrets.VALIDATION_DATABASE_URL }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run prisma schema validation
+        run: yarn prisma:check

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 # database
 /prisma/db.sqlite
 /prisma/db.sqlite-journal
-/prisma/migrations/* # Temporary ignore
+/prisma/migrations/*
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "prettier:check": "prettier --check ./src/**/*.{ts,tsx}",
     "prettier:fix": "prettier --write ./src/**/*.{ts,tsx}",
     "migration:generate": "prisma generate",
-    "migration:dev": "prisma migrate dev"
+    "migration:dev": "prisma migrate dev",
+    "prisma:check": "prisma validate",
+    "prisma:fix": "prisma format"
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.4",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,22 +17,22 @@ model Example {
 }
 
 model Account {
-  id                String  @id @default(cuid())
-  userId            String  @map("user_id")
+  id                String   @id @default(cuid())
+  userId            String   @map("user_id")
   type              String
   provider          String
-  providerAccountId String  @map("provider_account_id")
-  refresh_token     String? @db.Text
-  access_token      String? @db.Text
+  providerAccountId String   @map("provider_account_id")
+  refresh_token     String?  @db.Text
+  access_token      String?  @db.Text
   expires_at        Int?
   token_type        String?
   scope             String?
-  id_token          String? @db.Text
+  id_token          String?  @db.Text
   session_state     String?
   ok                Boolean?
   state             String?
 
-  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
   @@map("accounts")
@@ -63,18 +63,18 @@ model User {
 }
 
 model Log {
-  id            Int @id @default(autoincrement())
-  student_id    String
-  datetime      DateTime @default(now())
-  type          Int
-  has_key       Boolean
-  reader_id     Int
+  id         Int      @id @default(autoincrement())
+  student_id String
+  datetime   DateTime @default(now())
+  type       Int
+  has_key    Boolean
+  reader_id  Int
 
   @@map("logs")
 }
 
 model Reader {
-  id           Int @id @default(autoincrement())
+  id           Int    @id @default(autoincrement())
   client_id    String @unique
   client_token String
   name         String


### PR DESCRIPTION
## What does this PR do ? / PRの目的
- CIにprisma schemaのバリデーションを追加
- `.gitignore`のバグを修正

## Implementations / 実装したこと
- prisma schemaチェック用のworkflowを追加 aa8933ae53feeb69d368a3bc861df3755df74c20
- prismaのmigrationsファイル以下をgit管理から除外 1a28d15b6ae1c3a772c8e27c31221e7fdfddb958
- prisma schemaを整形 48514eb3604332ac351f6ec081591260a353cc27

## References / 参考資料
- [Prisma Validate](https://www.prisma.io/docs/reference/api-reference/command-reference#validate)
- [Prisma Format](https://www.prisma.io/docs/reference/api-reference/command-reference#format)