### PR TITLE
Build用のCIのエラーを修正

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,9 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
+      
+      - name: Generate Prisma Client
+        run: yarn run migration:generate
 
       - name: build
         run: yarn run build


### PR DESCRIPTION
## What does this PR do ? / PRの目的
PrismaのClientが生成されていないことにより、Build用のCIでエラーが出る問題を修正する

## Implementations / 実装したこと
- ビルドテスト時にPrisma Clientを生成するように修正 9a1bd0510d8141d8c89ffebd0caa16d4d1d9b985

## References / 参考資料
なし