### PR TITLE
LogTypeを定数化

### DIFF
--- a/src/server/trpc/router/log.ts
+++ b/src/server/trpc/router/log.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { LogType } from '../../../utils/const'
 import { adminProcedure, publicProcedure, router } from '../trpc'
 
 export const logRouter = router({
@@ -27,7 +28,7 @@ export const logRouter = router({
             }
           })
 
-          if (result?.type == 0) {
+          if (result?.type === LogType.ENTER) {
             return user.name
           }
         }

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,0 +1,6 @@
+export const LogType = {
+  ENTER: 0,
+  EXIT: 1,
+  TEMPORARY_EXIT: 2,
+  KEY_PICKUP: 3
+}


### PR DESCRIPTION
## What does this PR do ? / PRの目的
LogTypeを数字だけで扱うとわからなくなるので定数化する

## Implementations / 実装したこと
- LogTypeを定数化 3ae5a19e748d0846628e487b22055f38f28e1118

## References / 参考資料
なし