### PR TITLE
鍵を取りに行く場合のログ生成・削除処理を追加

### DIFF
--- a/src/pages/api/logs.ts
+++ b/src/pages/api/logs.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { generateHashedToken } from '../../utils/client'
 import { PrismaClient } from '@prisma/client'
+import { LogType } from '../../utils/const'
 
 const prisma = new PrismaClient()
 
@@ -17,6 +18,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return
     }
     const readerId = client.id
+
+    if (type === LogType.ENTER && hasKey) {
+      const result = await prisma.log.findFirst({
+        where: {
+          type: LogType.KEY_PICKUP
+        }
+      })
+
+      if (result !== null) {
+        await prisma.log.deleteMany({
+          where: {
+            type: LogType.KEY_PICKUP
+          }
+        })
+      }
+    }
+
     const log = await prisma.log.create({
       data: {
         reader_id: readerId,


### PR DESCRIPTION
## What does this PR do ? / PRの目的
鍵を取りに行く場合のログ生成・削除処理を追加

## Implementations / 実装したこと
- 鍵を取りに行く場合のログを生成・削除する処理をTRPCサーバ側に実装 1ee755b7357009d98556e6c4634df29fa24eba3d
- 鍵を持った状態で入室した場合はPickupログを削除するようにする 743a6fa35831b83848e53b34599824866aa3cb5c

## References / 参考資料
なし